### PR TITLE
Fix compile error on Linux 6.7 and above.

### DIFF
--- a/src/device.c
+++ b/src/device.c
@@ -130,7 +130,7 @@ akvcam_device_t akvcam_device_new(const char *name,
     akvcam_buffers_set_format(self->buffers, self->format);
     memset(&self->v4l2_dev, 0, sizeof(struct v4l2_device));
     snprintf(self->v4l2_dev.name,
-             V4L2_DEVICE_NAME_SIZE,
+             sizeof(self->v4l2_dev.name),
              "akvcam-device-%u", (uint) akvcam_id());
     akvcam_connect(controls, self->controls, updated, self, akvcam_device_controls_updated);
     akvcam_connect(buffers, self->buffers, streaming_started, self, akvcam_device_clock_start);


### PR DESCRIPTION
The `V4L2_DEVICE_NAME_SIZE` macro was removed in kernel version 6.7 (https://github.com/torvalds/linux/commit/06016a67c61675642c71358c2afe6ce99b5d1468).